### PR TITLE
Add multiline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ Run jq on your data and get result as output
 ### `multiline`
 Optional. Default `false`.
 
-If `multiline: true`, multiple lines of output will be captured. Useful
-for capturing lists.
-
-If `multiline: false`, only the first line of the output will be
-captured. The rest will be written to stdout.
+| Value | Behavior |
+| - | - |
+| true | Multiple lines of output will be captured. Useful for capturing lists. |
+| false | Only the first line of the output will be captured. The rest will be written to stdout. |
 
 ## Outputs
 
@@ -68,5 +67,4 @@ jobs:
           for keyword in $keywords; do
             echo "$keyword"
           done
-
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Run jq on your data and get result as output
 ### `cmd`
 **Required** This is the actual command that will be passed along
 
+### `multiline`
+Optional. Default `false`.
+
+If `multiline: true`, multiple lines of output will be captured. Useful
+for capturing lists.
+
+If `multiline: false`, only the first line of the output will be
+captured. The rest will be written to stdout.
+
 ## Outputs
 
 ### `value`
@@ -36,4 +45,28 @@ jobs:
       
       - name: Show my version
         run: 'echo "version ${{ steps.version.outputs.value }}"'
+```
+
+## Using multiline output
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - name: Extract all keywords from package.json
+        uses: sergeysova/jq-action@v2
+        id: keywords
+        with:
+          cmd: 'jq .keywords[] package.json -r'
+          multiline: true
+      
+      - name: Show keywords
+        run: |
+          keywords="${{ steps.keywords.outputs.value }}"
+          for keyword in $keywords; do
+            echo "$keyword"
+          done
+
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,11 @@ inputs:
   cmd:
     description: 'jq command with arguments'
     required: true
+  multiline:
+    description: 'If true, support multiline output'
+    required: false
+    type: boolean
+    default: false
 outputs:
   value:
     description: 'What jq is outputs'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 set -e
 
+OUTPUT=$(eval $INPUT_CMD)
+
+# Multiline string handling, per Github Community recommendation:
+# https://github.community/t/set-output-truncates-multiline-strings/16852/3
+if ($INPUT_MULTILINE); then
+  OUTPUT="${OUTPUT//'%'/'%25'}"
+  OUTPUT="${OUTPUT//$'\n'/'%0A'}"
+  OUTPUT="${OUTPUT//$'\r'/'%0D'}"
+fi
+
 echo "::set-output name=value::$(eval $INPUT_CMD)"


### PR DESCRIPTION
Closes #2 

- This is the recommended approach for multiline action output per Github engineering support: https://github.community/t/set-output-truncates-multiline-strings/16852/3.
- The default is `false` to maintain existing behavior.
- The README.md is updated with info on the new flag and an example.

Verified in my downstream repo here, where I've pulled the `.contributes.themes[].path` values from a VS Code Extension's package.json.

https://github.com/rosshamish/kuskus/blob/10facde2738451d026f9561df166cc32cf3d4e1d/.github/actions/kusto-color-themes/verify/action.yml#L8-L26
```yml
    - name: Extract contributed themes from package.json
      uses: ./.github/actions/jq-action-master
      id: themes
      with:
        cmd: 'jq .contributes.themes[].path ${{ inputs.working-directory }}/package.json --raw-output'
        multiline: true
    - name: Verify each contributed theme exists
      shell: bash
      run: |
        errors=0
        themes_in_package_json="${{ steps.themes.outputs.value }}"
        for theme in $themes_in_package_json; do
          filepath="${{ inputs.working-directory }}/$theme"
          if (!(test -f "$filepath")); then
            echo "ERROR: File not found: $filepath"
            errors+=1
          fi
        done
        exit $errors
```