### PR TITLE
fix: use correct multiline output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ if ($INPUT_MULTILINE); then
   OUTPUT="${OUTPUT//$'\r'/'%0D'}"
 fi
 
-echo "::set-output name=value::$(eval $INPUT_CMD)"
+echo "::set-output name=value::$OUTPUT"


### PR DESCRIPTION
Originally added in #3, there is a small difference between the code in this repo and [the code the original PR was based on](https://github.com/rosshamish/kuskus/blob/10facde2738451d026f9561df166cc32cf3d4e1d/.github/actions/jq-action-master/entrypoint.sh#L12), for the multiline output support.

This PR correctly returns the modified `$OUTPUT` value when asking for multiline output, rather than the original output.