### PR TITLE
Fix globbing in input

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-OUTPUT=$(eval $INPUT_CMD)
+OUTPUT=$(eval "$INPUT_CMD")
 
 # Multiline string handling, per Github Community recommendation:
 # https://github.community/t/set-output-truncates-multiline-strings/16852/3


### PR DESCRIPTION
If an asterisk is used as part of the input jq command it is expanded by the command substitution. If `INPUT_CMD` is double-quoted asterisks inside the jq command get passed on.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

If an asterisk is used as part of the input jq command it is expanded by the command substitution. If INPUT_CMD is double-quoted asterisks inside the jq command get passed on.

e.g

```
jq -r '.[] | @text " * | \(.name) | \(.currentMasterVersion)"' data/clusters*.json
```

gets expanded to

```
jq -r '.[] | @text " FILE1 FILE2 FILE3 | \(.name) | \(.currentMasterVersion)"' data/clusters1.json data/clusters2.json
```

instead of

```
jq -r '.[] | @text " * | \(.name) | \(.currentMasterVersion)"' data/clusters1.json data/clusters2.json
```

double-quoting fixes this.
<!--do not edit: pr-->
