### PR TITLE
Use $GITHUB_OUTPUT instead of set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ if ($INPUT_MULTILINE); then
   OUTPUT="${OUTPUT//$'\r'/'%0D'}"
 fi
 
-echo "::set-output name=value::$OUTPUT"
+echo "value=$OUTPUT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

[`set-ouput` has been deprecated since this October](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
).
GitHub introduced [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files).

This pull-request provides a change on entrypoint.sh which uses `set-output`.

Close #8 

<!--do not edit: pr-->
