### PR TITLE
Unpin Alpine version to prevent failure of the action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.11
+FROM alpine
 
 RUN apk add --no-cache ca-certificates bash curl jq
 


### PR DESCRIPTION
This Github Action is failing because Alpine has removed their images for version 3.11. I have unpinned the Dockerfile's Alpine layer so it will always use the latest release of Alpine to prevent this in the future. Since the only deps are bash, curl, and jq, which should always be available in Alpine, this should not be a problem for future versions of the action.

If anyone is reading this and is here because they found today that all of their Github Actions workflows using sergeysova/jq-action are failing with errors about Docker, you can temporarily update your action to use my fork `jasongill/jq-action@v2` until this PR is merged.